### PR TITLE
Fixed bug with removing labels on multiple graphs

### DIFF
--- a/jquery.flot.labels.js
+++ b/jquery.flot.labels.js
@@ -179,7 +179,7 @@ Also, version 0.2 takes into account the radius of the data points when placing 
         var series = plot.getData();
         for (var i = 0; i < series.length; i++) {
             if (!series[i].canvasRender && series[i].labelClass) {
-                $("." + series[i].labelClass).remove();
+                eventHolder.find("." + series[i].labelClass).remove();
             }
         }
     }


### PR DESCRIPTION
When we have many graphs, and redraw one of them => plugin removes all labels on all graphs and redraw them only on 1 graph.